### PR TITLE
Run chmod +x on git-hook

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -74,7 +74,12 @@ module.exports = generators.Base.extend({
       this.log(chalk.red('  skipping install of deps'));
       return;
     }
+    var _this = this;
+    this.spawnCommand('yarn', ['install']).on('close', function yarnClose() {
+      var isWin = /^win/.test(process.platform);
+      if(isWin) return;
 
-    this.spawnCommand('yarn', ['install']);
+      _this.spawnCommand('chmod', ['+x', '.git/hooks/pre-commit']);
+    });
   }
 });


### PR DESCRIPTION
The pre-commit package does not properly set the executable flag on the
newly generated precommit hook, which in effect means that no pre commit
hooks are executed.

Only executed on non windows platforms, as windows does not have the `chmod`
command

Fixes #1