### PR TITLE
Add nodejs engine >= 6.9.0 as requirement

### DIFF
--- a/generators/app/templates/config/_package.json
+++ b/generators/app/templates/config/_package.json
@@ -3,6 +3,9 @@
   "version": "<%= version %>",
   "author": "<%= author %>",
   "main": "lib/index.js",
+  "engines": {
+    "node": ">=6.9.0"
+  },
   "scripts" :{
     "lint": "./node_modules/.bin/eslint lib test",
     "test": "./node_modules/.bin/lab"


### PR DESCRIPTION
This is the LTS version now, so let's move the world onto node 6.9