### PR TITLE
Update eslinting rules

### DIFF
--- a/generators/app/templates/config/_eslintrc
+++ b/generators/app/templates/config/_eslintrc
@@ -2,8 +2,17 @@
   "extends": [
     "airbnb"
   ],
-   "rules": {
-     "arrow-body-style": 0,
-     "import/newline-after-import": 0
+    "rules": {
+      "arrow-body-style": 0,
+      "import/newline-after-import": 0,
+      // specify the maximum length of a line in your program
+      // http://eslint.org/docs/rules/max-len
+        'max-len': ['error', 160, 2, {
+          ignoreUrls: true,
+          ignoreComments: false,
+          ignoreRegExpLiterals: true,
+          ignoreStrings: true,
+          ignoreTemplateLiterals: true,
+        }],
    }
 }

--- a/generators/app/templates/config/_eslintrc
+++ b/generators/app/templates/config/_eslintrc
@@ -7,12 +7,14 @@
       "import/newline-after-import": 0,
       // specify the maximum length of a line in your program
       // http://eslint.org/docs/rules/max-len
-        'max-len': ['error', 160, 2, {
-          ignoreUrls: true,
-          ignoreComments: false,
-          ignoreRegExpLiterals: true,
-          ignoreStrings: true,
-          ignoreTemplateLiterals: true,
-        }],
+      "max-len": ["error", 160, 2, {
+        ignoreUrls: true,
+        ignoreComments: false,
+        ignoreRegExpLiterals: true,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true,
+      }],
+      "comma-dangle": 0,
+      "padded-blocks": 0
    }
 }


### PR DESCRIPTION
This pr updates the eslinter rules, but changing the allowed line length to 160, and disabling the rules "comma dangle" and "padded-blocks" 